### PR TITLE
Moved chai to devDependencies

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -6,10 +6,10 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "chai": "^3.4.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Test dependencies should be placed in the development dependencies section and shouldn't be `shrinkwrap`ped.
